### PR TITLE
add `_select` query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# json-server
+# json-server-extended
+
 
 [![Node.js CI](https://github.com/typicode/json-server/actions/workflows/node.js.yml/badge.svg)](https://github.com/typicode/json-server/actions/workflows/node.js.yml)
 
+> [!IMPORTANT]
+> This is a fork from original [json-server](https://github.com/typicode/json-server) repository
+upd
 > [!IMPORTANT]
 > Viewing beta v1 documentation – usable but expect breaking changes. For stable version, see [here](https://github.com/typicode/json-server/tree/v0)
 
@@ -10,7 +14,7 @@
 ## Install
 
 ```shell
-npm install json-server
+npm install json-server-extened
 ```
 
 ## Usage
@@ -163,6 +167,16 @@ GET /posts?_page=1&_per_page=25
 
 ```
 GET /posts?_sort=id,-views
+```
+
+### Select
+
+Specify fields which needs to be included in the response:
+
+- `_select=f1,f2`
+
+```
+GET /comments?_select=id,text
 ```
 
 ### Nested and array fields

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "json-server",
-  "version": "1.0.0-beta.1",
+  "name": "json-server-extended",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "bin": {
@@ -27,8 +27,15 @@
   "license": "SEE LICENSE IN ./LICENSE",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/typicode/json-server.git"
+    "url": "git+https://github.com/ivanzusko/json-server-extended.git"
   },
+  "bugs": {
+    "url": "https://github.com/ivanzusko/json-server-extended/issues",
+    "email": "ivan.zusko@gmail.com"
+  },
+  "contributors": [
+    "Ivan Zusko <ivan.zusko@gmail.com>"
+  ],
   "devDependencies": {
     "@sindresorhus/tsconfig": "^5.0.0",
     "@tailwindcss/typography": "^0.5.13",

--- a/src/service.ts
+++ b/src/service.ts
@@ -178,6 +178,7 @@ export class Service {
       _limit?: number
       _page?: number
       _per_page?: number
+      _select?: string | string[]
     } = {},
   ): Item[] | PaginatedItems | Item | undefined {
     let items = this.#get(name)
@@ -314,7 +315,27 @@ export class Service {
 
     // Sort
     const sort = query._sort || ''
-    const sorted = sortOn(res, sort.split(','))
+    let sorted = sortOn(res, sort.split(','))
+
+    // Keep only selected properties
+    if (conds.hasOwnProperty('_select')) {
+      let [_, paramValue] = conds['_select']
+
+      if (!Array.isArray(paramValue)) {
+        paramValue = paramValue.split(',')
+      }
+
+      sorted = sorted.map((item: Item) => {
+        let itemWithSelectedProperties: {
+          [k: string]: any
+        } = {}
+
+        paramValue.forEach(prop => {
+          itemWithSelectedProperties[prop] = item[prop]
+        })
+        return itemWithSelectedProperties
+      })
+    }
 
     // Slice
     const start = query._start


### PR DESCRIPTION
This PR adds `_select` query parameter which allows to specify which fields needs to be included in the response.

For example:
```js
```json
// GET http://localhost:3000/comments?_select=id,text

[
  {
    "id": "1",
    "text": "a comment about post 1"
  },
  {
    "id": "2",
    "text": "another comment about post 1"
  }
]
```

Fixes https://github.com/ivanzusko/json-server-extended/issues/1