### PR TITLE
Add search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [1.1.0] - 2024-08-13
+### Added
+- Search with `q` query parameter
+- CHANGELOG.md file
+
+
+## [1.0.0] - 2024-08-12
+### Added
+- `_select` - specifying properties which needs to be returned within the response,
+
+
+[1.1.0]: https://www.npmjs.com/package/json-server-extended/v/1.1.0
+[1.0.0]: https://www.npmjs.com/package/json-server-extended/v/1.0.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@
 [![Node.js CI](https://github.com/typicode/json-server/actions/workflows/node.js.yml/badge.svg)](https://github.com/typicode/json-server/actions/workflows/node.js.yml)
 
 > [!IMPORTANT]
-> This is a fork from original [json-server](https://github.com/typicode/json-server) repository
+> This is a fork from original [json-server](https://github.com/typicode/json-server) repository (`v1.0.0-beta.1`)
+
+## Modifications comparing to the original `json-server@v1.0.0-beta.1`
+
+- [Select](https://github.com/ivanzusko/json-server-extended?tab=readme-ov-file#select)
+- [Search](https://github.com/ivanzusko/json-server-extended?tab=readme-ov-file#search)
+
+[CHANGELOG.md](https://github.com/ivanzusko/json-server-extended/blob/main/CHANGELOG.md)
 
 > [!IMPORTANT]
 > Viewing beta v1 documentation – usable but expect breaking changes. For stable version, see [here](https://github.com/typicode/json-server/tree/v0)
@@ -139,6 +146,16 @@ PATCH /profile
 
 ```
 GET /posts?views_gt=9000
+```
+
+### Search
+
+Search isn't case sensitive
+
+- `q`
+
+```
+GET /posts?q=sometext
 ```
 
 ### Range

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-server",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "json-server",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.1",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@tinyhttp/app": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-server-extended",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "type": "module",
   "bin": {

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -270,6 +270,37 @@ await test('find', async (t) => {
       },
       {
         name: POSTS,
+        params: { _select: 'title,views' },
+        res: [
+          {
+            title: post1.title,
+            views: post1.views
+          },{
+            title: post2.title,
+            views: post2.views
+          },{
+            title: post3.title,
+            views: post3.views
+          }
+        ],
+      },
+      {
+        name: POSTS,
+        params: { q: 'b' },
+        res: [post2],
+      },
+      {
+        name: POSTS,
+        params: { q: 'johnny' },
+        res: [],
+      },
+      {
+        name: POSTS,
+        params: { q: '' },
+        res: [post1, post2, post3],
+      },
+      {
+        name: POSTS,
         params: { _embed: ['comments'] },
         res: [
           { ...post1, comments: [comment1] },

--- a/src/service.ts
+++ b/src/service.ts
@@ -179,6 +179,7 @@ export class Service {
       _page?: number
       _per_page?: number
       _select?: string | string[]
+      q?: string
     } = {},
   ): Item[] | PaginatedItems | Item | undefined {
     let items = this.#get(name)
@@ -316,6 +317,21 @@ export class Service {
     // Sort
     const sort = query._sort || ''
     let sorted = sortOn(res, sort.split(','))
+    const searchQuery = query.q
+
+    // Search
+    if (searchQuery != null && searchQuery != '') {
+      sorted = sorted.filter(item => {
+        for (const prop in item) {
+          if (typeof item[prop] === 'string') {
+            if (item[prop].toLowerCase().includes(searchQuery.toLowerCase()) ) {
+              return true
+            }
+          }
+        }
+        return false
+      })
+    }
 
     // Keep only selected properties
     if (conds.hasOwnProperty('_select')) {


### PR DESCRIPTION
This PR adds possibility to search with help of `q=` query parameter.
It makes shallow search (doesn't search in nested properties)

Fixes https://github.com/ivanzusko/json-server-extended/issues/4